### PR TITLE
Make ecl_tools build for ros2 (on windows 10)

### DIFF
--- a/ecl_build/CMakeLists.txt
+++ b/ecl_build/CMakeLists.txt
@@ -2,34 +2,31 @@
 # Cmake
 ##############################################################################
 
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(ecl_build)
 
 ##############################################################################
-# Catkin
+# ament
 ##############################################################################
 
-find_package(catkin REQUIRED)
+find_package(ament_cmake REQUIRED)
 
 set(${PROJECT_NAME}_MODULES "")
-list(APPEND ${PROJECT_NAME}_MODULES ecl_platform_detection.cmake)
-list(APPEND ${PROJECT_NAME}_MODULES ecl_package.cmake)
-list(APPEND ${PROJECT_NAME}_MODULES ecl_find_sse.cmake)
-list(APPEND ${PROJECT_NAME}_MODULES ecl_build_utilities.cmake)
-list(APPEND ${PROJECT_NAME}_MODULES ecl_cx11.cmake)
-list(APPEND ${PROJECT_NAME}_MODULES cotire.cmake)
+list(APPEND ${PROJECT_NAME}_MODULES ${CMAKE_SOURCE_DIR}/cmake/ecl_platform_detection.cmake)
+list(APPEND ${PROJECT_NAME}_MODULES ${CMAKE_SOURCE_DIR}/cmake/ecl_package.cmake)
+list(APPEND ${PROJECT_NAME}_MODULES ${CMAKE_SOURCE_DIR}/cmake/ecl_find_sse.cmake)
+list(APPEND ${PROJECT_NAME}_MODULES ${CMAKE_SOURCE_DIR}/cmake/ecl_build_utilities.cmake)
+list(APPEND ${PROJECT_NAME}_MODULES ${CMAKE_SOURCE_DIR}/cmake/ecl_cx11.cmake)
+list(APPEND ${PROJECT_NAME}_MODULES ${CMAKE_SOURCE_DIR}/cmake/cotire.cmake)
 
-catkin_package(
-    CFG_EXTRAS ${${PROJECT_NAME}_MODULES}
-)
-
+ament_export_include_directories(include)
+ament_package(CONFIG_EXTRAS ${${PROJECT_NAME}_MODULES})
 
 ##############################################################################
 # Work
 ##############################################################################
 
 install(DIRECTORY cmake
-        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+        DESTINATION share
 )
-
 

--- a/ecl_build/CMakeLists.txt
+++ b/ecl_build/CMakeLists.txt
@@ -20,7 +20,6 @@ list(APPEND ${PROJECT_NAME}_MODULES ${CMAKE_SOURCE_DIR}/cmake/ecl_cx11.cmake)
 list(APPEND ${PROJECT_NAME}_MODULES ${CMAKE_SOURCE_DIR}/cmake/cotire.cmake)
 
 ament_export_include_directories(include)
-ament_export_libraries(${PROJECT_NAME})
 ament_package(CONFIG_EXTRAS ${${PROJECT_NAME}_MODULES})
 
 ##############################################################################

--- a/ecl_build/CMakeLists.txt
+++ b/ecl_build/CMakeLists.txt
@@ -20,6 +20,7 @@ list(APPEND ${PROJECT_NAME}_MODULES ${CMAKE_SOURCE_DIR}/cmake/ecl_cx11.cmake)
 list(APPEND ${PROJECT_NAME}_MODULES ${CMAKE_SOURCE_DIR}/cmake/cotire.cmake)
 
 ament_export_include_directories(include)
+ament_export_libraries(${PROJECT_NAME})
 ament_package(CONFIG_EXTRAS ${${PROJECT_NAME}_MODULES})
 
 ##############################################################################

--- a/ecl_build/package.xml
+++ b/ecl_build/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>ecl_build</name>
   <version>0.61.7</version>
   <description>
@@ -13,9 +13,13 @@
   <url type="repository">https://github.com/stonier/ecl_tools</url>
   <url type="bugtracker">https://github.com/stonier/ecl_tools/issues</url>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
   <build_depend>ecl_license</build_depend>
-  <run_depend>ecl_license</run_depend>
+  <exec_depend>ecl_license</exec_depend>
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>
 
 

--- a/ecl_license/CMakeLists.txt
+++ b/ecl_license/CMakeLists.txt
@@ -2,16 +2,14 @@
 # Cmake
 ##############################################################################
 
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(ecl_license)
 
 ##############################################################################
-# Catkin
+# ament
 ##############################################################################
 
-find_package(catkin)
-
-catkin_package()
+find_package(ament_cmake)
 
 
 ##############################################################################
@@ -20,7 +18,10 @@ catkin_package()
 
 
 install(DIRECTORY licenses 
-        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+        DESTINATION share
         PATTERN ".svn" EXCLUDE
         PATTERN "CMakeLists.txt" EXCLUDE
        )
+
+ament_export_include_directories(include)
+ament_package()

--- a/ecl_license/CMakeLists.txt
+++ b/ecl_license/CMakeLists.txt
@@ -24,4 +24,5 @@ install(DIRECTORY licenses
        )
 
 ament_export_include_directories(include)
+ament_export_libraries(${PROJECT_NAME})
 ament_package()

--- a/ecl_license/package.xml
+++ b/ecl_license/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>ecl_license</name>
   <version>0.61.7</version>
   <description>
@@ -13,7 +13,10 @@
   <url type="repository">https://github.com/stonier/ecl_tools</url>
   <url type="bugtracker">https://github.com/stonier/ecl_tools/issues</url>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>
 
 

--- a/ecl_tools/CMakeLists.txt
+++ b/ecl_tools/CMakeLists.txt
@@ -1,4 +1,6 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(ecl_tools)
-find_package(catkin REQUIRED)
-catkin_metapackage()
+find_package(ament_cmake REQUIRED)
+#catkin_metapackage()
+
+ament_package()

--- a/ecl_tools/package.xml
+++ b/ecl_tools/package.xml
@@ -1,4 +1,5 @@
-<package>
+<?xml version="1.0"?>
+<package format="2">
   <name>ecl_tools</name>
   <version>0.61.7</version>
   <description>
@@ -11,10 +12,12 @@
   <url type="repository">https://github.com/stonier/ecl_tools</url>
   <url type="bugtracker">https://github.com/stonier/ecl_tools/issues</url>
 
-  <buildtool_depend>catkin</buildtool_depend>
-  <run_depend>ecl_license</run_depend>
-  <run_depend>ecl_build</run_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <exec_depend>ecl_license</exec_depend>
+  <exec_depend>ecl_build</exec_depend>
   <export>
+    <build_type>ament_cmake</build_type>
     <metapackage/>
   </export>
 </package>


### PR DESCRIPTION
This is a part of an effort to port Kobuki and Turtlebot2 to ROS2 and Windows 10.

Ported ecl_tools, ecl_core, ecl_lite, & ecl_navigation to ament build system.