### PR TITLE
[ecl_build] cmake 3+ style cxx std and decouple -W options

### DIFF
--- a/ecl_build/cmake/ecl_cxx.cmake
+++ b/ecl_build/cmake/ecl_cxx.cmake
@@ -24,12 +24,18 @@ endmacro()
 # Might prefer to handle it better using the cmake variables
 # e.g. https://github.com/ros2/realtime_support/blob/master/tlsf_cpp/CMakeLists.txt#L10
 macro(ecl_enable_cxx14_compiler)
-  ecl_check_for_cxx14_compiler(CXX14_COMPILER_FOUND)
-  if(CXX14_COMPILER_FOUND)
-    # Includes additional flags that the ros2 libraries build in by default
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra -Werror -Wpedantic")
-  else()
-    message(FATAL_ERROR "Requested cxx14 flags, but this compiler does not support it.")
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)  # aborts with an error if the requested standard is not available
+  set(CMAKE_CXX_EXTENSIONS OFF)  # if ON, it will use gnu++14 instead of std++14
+  set(CMAKE_CXX_STANDARD 14)
+  #else()
+  #  message(FATAL_ERROR "Requested cxx14 flags, but this compiler does not support it.")
+  #endif()
+endmacro()
+
+# Enable the kitchen sink, i.e. as much as possible.
+macro(ecl_enable_cxx_warnings)
+  if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_compile_options(-Wall -Wextra -Werror -Wpedantic)
   endif()
 endmacro()
 

--- a/ecl_build/cmake/ecl_cxx.cmake
+++ b/ecl_build/cmake/ecl_cxx.cmake
@@ -27,7 +27,7 @@ macro(ecl_enable_cxx14_compiler)
   ecl_check_for_cxx14_compiler(CXX14_COMPILER_FOUND)
   if(CXX14_COMPILER_FOUND)
     # Includes additional flags that the ros2 libraries build in by default
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra -Wl,--no-as-needed")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra -Werror -Wpedantic")
   else()
     message(FATAL_ERROR "Requested cxx14 flags, but this compiler does not support it.")
   endif()

--- a/ecl_build/cmake/ecl_cxx.cmake
+++ b/ecl_build/cmake/ecl_cxx.cmake
@@ -21,15 +21,11 @@ endmacro()
 # Enable
 ##############################################################################
 
-# Might prefer to handle it better using the cmake variables
-# e.g. https://github.com/ros2/realtime_support/blob/master/tlsf_cpp/CMakeLists.txt#L10
+# Enable CXX14 and abort if not available
 macro(ecl_enable_cxx14_compiler)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)  # aborts with an error if the requested standard is not available
   set(CMAKE_CXX_EXTENSIONS OFF)  # if ON, it will use gnu++14 instead of std++14
   set(CMAKE_CXX_STANDARD 14)
-  #else()
-  #  message(FATAL_ERROR "Requested cxx14 flags, but this compiler does not support it.")
-  #endif()
 endmacro()
 
 # Enable the kitchen sink, i.e. as much as possible.


### PR DESCRIPTION
* Simpler, more cross platform means of checking against cxx standards
* Enable warnings decoupled from the cxx standards
* Introduce `-Werror` and `-Wpedantic`
* Drop drop `-Wl, -no-as-needed`, not ideal and doesn't seem to be necessary any longer

