### PR TITLE
Fix finding of Thread libraries.

### DIFF
--- a/ecl_build/cmake/ecl_platform_detection.cmake
+++ b/ecl_build/cmake/ecl_platform_detection.cmake
@@ -222,7 +222,7 @@ macro(ecl_detect_threads)
   if(DEFINED ECL_PLATFORM_HAS_POSIX_THREADS OR ECL_PLATFORM_HAS_WIN32_THREADS)
     # Do nothing
   else()
-    include(FindThreads)
+    find_package(Threads)
     if(CMAKE_USE_PTHREADS_INIT)
       set(ECL_PLATFORM_HAS_POSIX_THREADS TRUE CACHE BOOL "platform has posix threads.")
     elseif(CMAKE_USE_WIN32_THREADS_INIT)


### PR DESCRIPTION
Instead of include(FindThreads), use find_package(Threads), which is the correct way to do this.  This removes a warning when using this with CMake >= 3.24.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This will get rid of warnings that look like:

```
CMake Warning (dev) at /usr/share/cmake-3.22/Modules/FindPackageHandleStandardArgs.cmake:438 (message):
  The package name passed to `find_package_handle_standard_args` (Threads)
  does not match the name of the calling package (ecl_threads).  This can
  lead to problems in calling code that expects `find_package` result
  variables (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/FindThreads.cmake:238 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  /home/ubuntu/kobuki_ws/install/ecl_build/share/ecl_build/cmake/ecl_platform_detection.cmake:225 (include)
  /home/ubuntu/kobuki_ws/install/ecl_threads/share/ecl_threads/cmake/ecl_threads-extras.cmake:4 (ecl_detect_threads)
  /home/ubuntu/kobuki_ws/install/ecl_threads/share/ecl_threads/cmake/ecl_threadsConfig.cmake:41 (include)
  CMakeLists.txt:19 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

And should fix https://github.com/stonier/ecl_core/issues/106 .  @stonier FYI.