### PR TITLE
Replacing BSD with BSD-3-Clause in package.xml

### DIFF
--- a/ecl_build/package.xml
+++ b/ecl_build/package.xml
@@ -8,7 +8,7 @@
   </description>
   <author email="d.stonier@gmail.com">Daniel Stonier</author>
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://wiki.ros.org/ecl_build</url>
   <url type="repository">https://github.com/stonier/ecl_tools</url>
   <url type="bugtracker">https://github.com/stonier/ecl_tools/issues</url>

--- a/ecl_license/package.xml
+++ b/ecl_license/package.xml
@@ -8,7 +8,7 @@
   </description>
   <author email="d.stonier@gmail.com">Daniel Stonier</author>
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://wiki.ros.org/ecl_license</url>
   <url type="repository">https://github.com/stonier/ecl_tools</url>
   <url type="bugtracker">https://github.com/stonier/ecl_tools/issues</url>

--- a/ecl_tools/package.xml
+++ b/ecl_tools/package.xml
@@ -7,7 +7,7 @@
   </description>
   <author email="d.stonier@gmail.com">Daniel Stonier</author>
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://www.ros.org/wiki/ecl_tools</url>
   <url type="repository">https://github.com/stonier/ecl_tools</url>
   <url type="bugtracker">https://github.com/stonier/ecl_tools/issues</url>


### PR DESCRIPTION
Updating the package.xml license tags to hold valid SPDX qualifiers. The rationale behind this is, that with
[meta-ros](https://github.com/ros/meta-ros) and
[superflore](https://github.com/ros-infrastructure/superflore) recipes get generated for the OpenEmbedded Linux build system. It will fetch the license tag and copy it over into the recipe. If no valid SPDX identifiers get found, it will issue an error, and a manual step to fix this is needed.

See the SPDX identifiers
[BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html)